### PR TITLE
Add support for import.meta properties replacement

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -21,7 +21,8 @@
     ]
   },
   "exclude": [
-    ".coverage/**"
+    ".coverage/**",
+    "testdata/**"
   ],
   "tasks": {
     "check": "deno check **/*.ts",

--- a/import_map_importer_import_meta_url_test.ts
+++ b/import_map_importer_import_meta_url_test.ts
@@ -1,0 +1,498 @@
+import { afterAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { fromFileUrl } from "@std/path/from-file-url";
+import { dirname } from "@std/path/dirname";
+import { ImportMapImporter } from "./import_map_importer.ts";
+import type { ImportMap } from "./import_map.ts";
+
+afterAll(async () => {
+  try {
+    const cacheDir = fromFileUrl(
+      new URL("./.test_cache", import.meta.url),
+    );
+    await Deno.remove(cacheDir, { recursive: true });
+  } catch (error) {
+    // Only ignore NotFound errors
+    if (!(error instanceof Deno.errors.NotFound)) {
+      throw error;
+    }
+  }
+});
+
+describe("ImportMapImporter - import.meta.url replacement", () => {
+  it("should preserve original import.meta.url when module is transformed", async () => {
+    const testModuleUrl = new URL(
+      "./testdata/import_meta_url.ts",
+      import.meta.url,
+    );
+    const importMap: ImportMap = {
+      imports: {},
+    };
+
+    const importer = new ImportMapImporter(importMap, {
+      cacheDir: "./.test_cache",
+    });
+
+    const module = await importer.import<{
+      currentUrl: string;
+      dirname: string;
+      getRelativePath: (path: string) => string;
+      metadata: {
+        url: string;
+        protocol: string;
+        pathname: string;
+      };
+    }>(testModuleUrl.href);
+
+    // The import.meta.url should point to the original file, not the cached version
+    expect(module.currentUrl).toBe(testModuleUrl.href);
+    expect(module.metadata.url).toBe(testModuleUrl.href);
+    expect(module.metadata.pathname).toBe(testModuleUrl.pathname);
+
+    // Test that relative URL resolution still works correctly
+    const relativePath = module.getRelativePath("./test.txt");
+    expect(relativePath).toBe(new URL("./test.txt", testModuleUrl).href);
+  });
+
+  it("should handle import.meta.url in modules with import mappings", async () => {
+    // Create a test module that uses both import mappings and import.meta.url
+    const testContent = `
+import { getValue } from "@test/lib";
+
+export const moduleUrl = import.meta.url;
+export const libValue = getValue();
+export const resourcePath = new URL("./resource.json", import.meta.url).href;
+`;
+
+    const libContent = `
+export function getValue() {
+  return "lib-value";
+}
+
+export const libUrl = import.meta.url;
+`;
+
+    const testModulePath = new URL(
+      "./testdata/test_import_meta_with_mapping.ts",
+      import.meta.url,
+    );
+    const libModulePath = new URL(
+      "./testdata/test_lib_for_meta.ts",
+      import.meta.url,
+    );
+
+    await Deno.writeTextFile(testModulePath, testContent);
+    await Deno.writeTextFile(libModulePath, libContent);
+
+    try {
+      const importMap: ImportMap = {
+        imports: {
+          "@test/lib": libModulePath.href,
+        },
+      };
+
+      const importer = new ImportMapImporter(importMap, {
+        cacheDir: "./.test_cache",
+      });
+
+      const module = await importer.import<{
+        moduleUrl: string;
+        libValue: string;
+        resourcePath: string;
+      }>(testModulePath.href);
+
+      // Both the main module and the imported lib should have their original URLs
+      expect(module.moduleUrl).toBe(testModulePath.href);
+      expect(module.libValue).toBe("lib-value");
+      expect(module.resourcePath).toBe(
+        new URL("./resource.json", testModulePath).href,
+      );
+
+      // Import the lib module directly to check its URL
+      const libModule = await importer.import<{ libUrl: string }>(
+        libModulePath.href,
+      );
+      expect(libModule.libUrl).toBe(libModulePath.href);
+    } finally {
+      await Deno.remove(testModulePath);
+      await Deno.remove(libModulePath);
+    }
+  });
+
+  it("should handle import.meta.url in deeply nested dependencies", async () => {
+    // Create a chain of dependencies all using import.meta.url
+    const deepContent = `
+export const deepUrl = import.meta.url;
+export const deepName = "deep";
+`;
+
+    const middleContent = `
+import { deepUrl, deepName } from "./deep.ts";
+
+export const middleUrl = import.meta.url;
+export const fromDeep = { deepUrl, deepName };
+export const middleName = "middle";
+`;
+
+    const topContent = `
+import { middleUrl, fromDeep, middleName } from "@test/middle";
+
+export const topUrl = import.meta.url;
+export const fromMiddle = { middleUrl, middleName };
+export const allUrls = {
+  top: import.meta.url,
+  middle: middleUrl,
+  deep: fromDeep.deepUrl,
+};
+`;
+
+    const deepPath = new URL("./testdata/deep.ts", import.meta.url);
+    const middlePath = new URL("./testdata/middle.ts", import.meta.url);
+    const topPath = new URL("./testdata/top.ts", import.meta.url);
+
+    await Deno.writeTextFile(deepPath, deepContent);
+    await Deno.writeTextFile(middlePath, middleContent);
+    await Deno.writeTextFile(topPath, topContent);
+
+    try {
+      const importMap: ImportMap = {
+        imports: {
+          "@test/middle": middlePath.href,
+        },
+      };
+
+      const importer = new ImportMapImporter(importMap, {
+        cacheDir: "./.test_cache",
+      });
+
+      const module = await importer.import<{
+        topUrl: string;
+        fromMiddle: { middleUrl: string; middleName: string };
+        allUrls: {
+          top: string;
+          middle: string;
+          deep: string;
+        };
+      }>(topPath.href);
+
+      // All URLs should point to their original locations
+      expect(module.topUrl).toBe(topPath.href);
+      expect(module.allUrls.top).toBe(topPath.href);
+      expect(module.allUrls.middle).toBe(middlePath.href);
+      expect(module.allUrls.deep).toBe(deepPath.href);
+      expect(module.fromMiddle.middleUrl).toBe(middlePath.href);
+    } finally {
+      await Deno.remove(deepPath);
+      await Deno.remove(middlePath);
+      await Deno.remove(topPath);
+    }
+  });
+
+  it("should handle import.meta.url with various usage patterns", async () => {
+    // Test various ways import.meta.url might be used
+    const testContent = `
+// Direct usage
+export const url1 = import.meta.url;
+
+// In template literal
+export const url2 = \`Current module: \${import.meta.url}\`;
+
+// As part of URL construction
+export const url3 = new URL("../data", import.meta.url).href;
+
+// In a function
+export function getModuleInfo() {
+  return {
+    url: import.meta.url,
+    dir: new URL(".", import.meta.url).href,
+  };
+}
+
+// In conditional
+export const isFileProtocol = import.meta.url.startsWith("file://");
+
+// Multiple uses in one line
+export const urls = [import.meta.url, import.meta.url];
+`;
+
+    const testPath = new URL(
+      "./testdata/various_import_meta_usage.ts",
+      import.meta.url,
+    );
+    await Deno.writeTextFile(testPath, testContent);
+
+    try {
+      const importMap: ImportMap = { imports: {} };
+      const importer = new ImportMapImporter(importMap, {
+        cacheDir: "./.test_cache",
+      });
+
+      const module = await importer.import<{
+        url1: string;
+        url2: string;
+        url3: string;
+        getModuleInfo: () => { url: string; dir: string };
+        isFileProtocol: boolean;
+        urls: string[];
+      }>(testPath.href);
+
+      // All instances should have the original URL
+      expect(module.url1).toBe(testPath.href);
+      expect(module.url2).toBe(`Current module: ${testPath.href}`);
+      expect(module.url3).toBe(new URL("../data", testPath).href);
+
+      const moduleInfo = module.getModuleInfo();
+      expect(moduleInfo.url).toBe(testPath.href);
+      expect(moduleInfo.dir).toBe(new URL(".", testPath).href);
+
+      expect(module.isFileProtocol).toBe(true);
+      expect(module.urls).toEqual([testPath.href, testPath.href]);
+    } finally {
+      await Deno.remove(testPath);
+    }
+  });
+
+  it("should handle import.meta.filename and import.meta.dirname", async () => {
+    const testModuleUrl = new URL(
+      "./testdata/import_meta_all.ts",
+      import.meta.url,
+    );
+    const importMap: ImportMap = {
+      imports: {},
+    };
+
+    const importer = new ImportMapImporter(importMap, {
+      cacheDir: "./.test_cache",
+    });
+
+    const module = await importer.import<{
+      metaUrl: string;
+      metaFilename: string;
+      metaDirname: string;
+      getFileInfo: () => {
+        url: string;
+        filename: string;
+        dirname: string;
+        basename: string | undefined;
+      };
+      isTypeScript: boolean;
+      parentDir: string | undefined;
+      dataPath: string;
+      configPath: string;
+    }>(testModuleUrl.href);
+
+    const expectedFilename = fromFileUrl(testModuleUrl);
+    const expectedDirname = dirname(expectedFilename);
+
+    // Check direct exports
+    expect(module.metaUrl).toBe(testModuleUrl.href);
+    expect(module.metaFilename).toBe(expectedFilename);
+    expect(module.metaDirname).toBe(expectedDirname);
+
+    // Check function return values
+    const fileInfo = module.getFileInfo();
+    expect(fileInfo.url).toBe(testModuleUrl.href);
+    expect(fileInfo.filename).toBe(expectedFilename);
+    expect(fileInfo.dirname).toBe(expectedDirname);
+    expect(fileInfo.basename).toBe("import_meta_all.ts");
+
+    // Check expressions
+    expect(module.isTypeScript).toBe(true);
+    expect(module.parentDir).toBe("testdata");
+    expect(module.dataPath).toBe(expectedDirname + "/data");
+    expect(module.configPath).toBe(`${expectedDirname}/config.json`);
+  });
+
+  it("should handle filename and dirname in modules with import mappings", async () => {
+    const testContent = `
+import { getValue } from "@test/lib";
+
+export const moduleInfo = {
+  url: import.meta.url,
+  filename: import.meta.filename,
+  dirname: import.meta.dirname,
+  value: getValue(),
+};
+`;
+
+    const libContent = `
+export function getValue() {
+  return {
+    libUrl: import.meta.url,
+    libFilename: import.meta.filename,
+    libDirname: import.meta.dirname,
+  };
+}
+`;
+
+    const testModulePath = new URL(
+      "./testdata/test_meta_all_with_mapping.ts",
+      import.meta.url,
+    );
+    const libModulePath = new URL(
+      "./testdata/test_lib_meta_all.ts",
+      import.meta.url,
+    );
+
+    await Deno.writeTextFile(testModulePath, testContent);
+    await Deno.writeTextFile(libModulePath, libContent);
+
+    try {
+      const importMap: ImportMap = {
+        imports: {
+          "@test/lib": libModulePath.href,
+        },
+      };
+
+      const importer = new ImportMapImporter(importMap, {
+        cacheDir: "./.test_cache",
+      });
+
+      const module = await importer.import<{
+        moduleInfo: {
+          url: string;
+          filename: string;
+          dirname: string;
+          value: {
+            libUrl: string;
+            libFilename: string;
+            libDirname: string;
+          };
+        };
+      }>(testModulePath.href);
+
+      const expectedTestFilename = fromFileUrl(testModulePath);
+      const expectedTestDirname = dirname(expectedTestFilename);
+      const expectedLibFilename = fromFileUrl(libModulePath);
+      const expectedLibDirname = dirname(expectedLibFilename);
+
+      // Check main module values
+      expect(module.moduleInfo.url).toBe(testModulePath.href);
+      expect(module.moduleInfo.filename).toBe(expectedTestFilename);
+      expect(module.moduleInfo.dirname).toBe(expectedTestDirname);
+
+      // Check lib module values
+      expect(module.moduleInfo.value.libUrl).toBe(libModulePath.href);
+      expect(module.moduleInfo.value.libFilename).toBe(expectedLibFilename);
+      expect(module.moduleInfo.value.libDirname).toBe(expectedLibDirname);
+    } finally {
+      await Deno.remove(testModulePath);
+      await Deno.remove(libModulePath);
+    }
+  });
+
+  it("should handle import.meta.resolve()", async () => {
+    const testModuleUrl = new URL(
+      "./testdata/import_meta_resolve.ts",
+      import.meta.url,
+    );
+    const importMap: ImportMap = {
+      imports: {
+        "@std/path": "jsr:@std/path@^1.0.1",
+      },
+    };
+
+    const importer = new ImportMapImporter(importMap, {
+      cacheDir: "./.test_cache",
+    });
+
+    const module = await importer.import<{
+      resolvedUrl: string;
+      resolvedRelative: string;
+      resolvedBare: string;
+      resolveCustom: (path: string) => string;
+      resolvedInExpression: URL;
+      resolvedArray: string[];
+      resolveDynamic: (moduleName: string) => Promise<string>;
+    }>(testModuleUrl.href);
+
+    // Check that resolved URLs are correct
+    const baseUrl = testModuleUrl.href;
+    expect(module.resolvedUrl).toBe(new URL("./dep1.ts", baseUrl).href);
+    expect(module.resolvedRelative).toBe(
+      new URL("../testdata/dep2.ts", baseUrl).href,
+    );
+    expect(module.resolvedBare).toBe(new URL("@std/path", baseUrl).href);
+
+    // Test dynamic resolution
+    const customResolved = module.resolveCustom("./custom.ts");
+    expect(customResolved).toBe(new URL("./custom.ts", baseUrl).href);
+
+    // Check array of resolved URLs
+    expect(module.resolvedArray).toEqual([
+      new URL("./file1.ts", baseUrl).href,
+      new URL("./file2.ts", baseUrl).href,
+    ]);
+  });
+
+  it("should handle import.meta.resolve() with import map transformations", async () => {
+    const testContent = `
+import { getValue } from "@test/lib";
+
+export const resolvedLib = import.meta.resolve("@test/lib");
+export const resolvedRelative = import.meta.resolve("./local.ts");
+export const value = getValue();
+
+export function resolveModule(name: string) {
+  return import.meta.resolve(name);
+}
+`;
+
+    const libContent = `
+export function getValue() {
+  return "lib-value";
+}
+
+export const libResolved = import.meta.resolve("./helper.ts");
+`;
+
+    const testModulePath = new URL(
+      "./testdata/test_resolve_with_mapping.ts",
+      import.meta.url,
+    );
+    const libModulePath = new URL(
+      "./testdata/test_lib_resolve.ts",
+      import.meta.url,
+    );
+
+    await Deno.writeTextFile(testModulePath, testContent);
+    await Deno.writeTextFile(libModulePath, libContent);
+
+    try {
+      const importMap: ImportMap = {
+        imports: {
+          "@test/lib": libModulePath.href,
+        },
+      };
+
+      const importer = new ImportMapImporter(importMap, {
+        cacheDir: "./.test_cache",
+      });
+
+      const module = await importer.import<{
+        resolvedLib: string;
+        resolvedRelative: string;
+        value: string;
+        resolveModule: (name: string) => string;
+      }>(testModulePath.href);
+
+      // Check that resolved URLs are relative to the original module locations
+      expect(module.resolvedLib).toBe(
+        new URL("@test/lib", testModulePath).href,
+      );
+      expect(module.resolvedRelative).toBe(
+        new URL("./local.ts", testModulePath).href,
+      );
+      expect(module.value).toBe("lib-value");
+
+      // Test dynamic resolution
+      const dynamicResolved = module.resolveModule("./dynamic.ts");
+      expect(dynamicResolved).toBe(
+        new URL("./dynamic.ts", testModulePath).href,
+      );
+    } finally {
+      await Deno.remove(testModulePath);
+      await Deno.remove(libModulePath);
+    }
+  });
+});

--- a/replace_import_meta.ts
+++ b/replace_import_meta.ts
@@ -1,0 +1,76 @@
+import { fromFileUrl } from "@std/path/from-file-url";
+import { dirname as pathDirname } from "@std/path/dirname";
+
+/**
+ * Replaces all occurrences of import.meta properties in source code with their original values.
+ *
+ * @param sourceCode - The source code to process
+ * @param originalUrl - The original URL to replace import.meta.url with
+ * @returns The source code with import.meta properties replaced
+ */
+export function replaceImportMeta(
+  sourceCode: string,
+  originalUrl: string,
+): string {
+  // Use JSON.stringify for robust escaping, then remove the quotes
+  const escapedUrl = JSON.stringify(originalUrl).slice(1, -1);
+
+  // Convert file URL to path for filename and dirname
+  let filename = "";
+  let dirname = "";
+
+  if (originalUrl.startsWith("file://")) {
+    // Use fromFileUrl to properly handle cross-platform paths
+    filename = fromFileUrl(originalUrl);
+    dirname = pathDirname(filename);
+
+    // Use JSON.stringify for robust escaping, then remove the quotes
+    filename = JSON.stringify(filename).slice(1, -1);
+    dirname = JSON.stringify(dirname).slice(1, -1);
+  }
+
+  // Match import.meta.url with various whitespace patterns
+  const importMetaUrlRegex = /\bimport\s*\.\s*meta\s*\.\s*url\b/g;
+
+  // Match import.meta.filename
+  const importMetaFilenameRegex = /\bimport\s*\.\s*meta\s*\.\s*filename\b/g;
+
+  // Match import.meta.dirname
+  const importMetaDirnameRegex = /\bimport\s*\.\s*meta\s*\.\s*dirname\b/g;
+
+  // Match import.meta.resolve() - captures the argument
+  const importMetaResolveRegex =
+    /\bimport\s*\.\s*meta\s*\.\s*resolve\s*\(\s*([^)]+)\s*\)/g;
+
+  // Replace all import.meta properties
+  let result = sourceCode.replace(importMetaUrlRegex, `"${escapedUrl}"`);
+
+  if (filename) {
+    result = result.replace(importMetaFilenameRegex, `"${filename}"`);
+  }
+
+  if (dirname) {
+    result = result.replace(importMetaDirnameRegex, `"${dirname}"`);
+  }
+
+  // Replace import.meta.resolve() with a new URL() expression
+  result = result.replace(importMetaResolveRegex, (_match, arg) => {
+    // Create a replacement that resolves the URL relative to the original module URL
+    // Trim whitespace around the argument while preserving internal structure
+    const trimmedArg = arg.trim();
+    return `new URL(${trimmedArg}, "${escapedUrl}").href`;
+  });
+
+  return result;
+}
+
+/**
+ * Creates a comment banner that indicates the original source file.
+ * This helps developers understand where the cached file came from.
+ *
+ * @param originalUrl - The original URL of the source file
+ * @returns A comment banner to prepend to the transformed code
+ */
+export function createOriginalUrlComment(originalUrl: string): string {
+  return `// Original source: ${originalUrl}\n// This file has been transformed by ImportMapImporter\n// import.meta.url, import.meta.filename, import.meta.dirname, and import.meta.resolve() have been replaced\n\n`;
+}

--- a/replace_import_meta_test.ts
+++ b/replace_import_meta_test.ts
@@ -1,0 +1,352 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  createOriginalUrlComment,
+  replaceImportMeta,
+} from "./replace_import_meta.ts";
+
+describe("replaceImportMeta", () => {
+  it("should replace basic import.meta.url", () => {
+    const code = `const url = import.meta.url;`;
+    const result = replaceImportMeta(code, "file:///original/path.ts");
+    expect(result).toBe(`const url = "file:///original/path.ts";`);
+  });
+
+  it("should replace import.meta.filename", () => {
+    const code = `const filename = import.meta.filename;`;
+    const result = replaceImportMeta(
+      code,
+      "file:///original/path/module.ts",
+    );
+    const expected = Deno.build.os === "windows"
+      ? `const filename = "\\\\original\\\\path\\\\module.ts";`
+      : `const filename = "/original/path/module.ts";`;
+    expect(result).toBe(expected);
+  });
+
+  it("should replace import.meta.dirname", () => {
+    const code = `const dirname = import.meta.dirname;`;
+    const result = replaceImportMeta(
+      code,
+      "file:///original/path/module.ts",
+    );
+    const expected = Deno.build.os === "windows"
+      ? `const dirname = "\\\\original\\\\path";`
+      : `const dirname = "/original/path";`;
+    expect(result).toBe(expected);
+  });
+
+  it("should replace all import.meta properties in one file", () => {
+    const code = `
+      const url = import.meta.url;
+      const filename = import.meta.filename;
+      const dirname = import.meta.dirname;
+    `;
+    const result = replaceImportMeta(code, "file:///test/dir/file.ts");
+    const expectedFilename = Deno.build.os === "windows"
+      ? "\\\\test\\\\dir\\\\file.ts"
+      : "/test/dir/file.ts";
+    const expectedDirname = Deno.build.os === "windows"
+      ? "\\\\test\\\\dir"
+      : "/test/dir";
+    expect(result).toBe(`
+      const url = "file:///test/dir/file.ts";
+      const filename = "${expectedFilename}";
+      const dirname = "${expectedDirname}";
+    `);
+  });
+
+  it("should handle import.meta properties with whitespace variations", () => {
+    const expectedFilename = Deno.build.os === "windows"
+      ? `"\\\\test\\\\file.ts"`
+      : `"/test/file.ts"`;
+    const expectedDirname = Deno.build.os === "windows"
+      ? `"\\\\test"`
+      : `"/test"`;
+
+    const testCases = [
+      { code: `import.meta.filename`, expected: expectedFilename },
+      { code: `import . meta . filename`, expected: expectedFilename },
+      { code: `import\n.meta.dirname`, expected: expectedDirname },
+      { code: `import\n.\nmeta\n.\ndirname`, expected: expectedDirname },
+    ];
+
+    for (const { code, expected } of testCases) {
+      const fullCode = `const x = ${code};`;
+      const result = replaceImportMeta(fullCode, "file:///test/file.ts");
+      expect(result).toBe(`const x = ${expected};`);
+    }
+  });
+
+  it("should not replace filename/dirname for non-file URLs", () => {
+    const code = `
+      const url = import.meta.url;
+      const filename = import.meta.filename;
+      const dirname = import.meta.dirname;
+    `;
+    const result = replaceImportMeta(code, "https://example.com/module.ts");
+    expect(result).toBe(`
+      const url = "https://example.com/module.ts";
+      const filename = import.meta.filename;
+      const dirname = import.meta.dirname;
+    `);
+  });
+
+  it("should replace import.meta.url with whitespace variations", () => {
+    const testCases = [
+      `import.meta.url`,
+      `import . meta . url`,
+      `import\n.meta.url`,
+      `import\n.\nmeta\n.\nurl`,
+      `import  .  meta  .  url`,
+    ];
+
+    for (const testCase of testCases) {
+      const code = `const x = ${testCase};`;
+      const result = replaceImportMeta(code, "file:///test.ts");
+      expect(result).toBe(`const x = "file:///test.ts";`);
+    }
+  });
+
+  it("should replace multiple occurrences", () => {
+    const code = `
+      const url1 = import.meta.url;
+      const url2 = import.meta.url;
+      console.log(import.meta.url);
+    `;
+    const result = replaceImportMeta(code, "file:///test.ts");
+    expect(result).toBe(`
+      const url1 = "file:///test.ts";
+      const url2 = "file:///test.ts";
+      console.log("file:///test.ts");
+    `);
+  });
+
+  it("should handle import.meta.url in template literals", () => {
+    const code = "const msg = `Current URL: ${import.meta.url}`;";
+    const result = replaceImportMeta(code, "file:///test.ts");
+    expect(result).toBe('const msg = `Current URL: ${"file:///test.ts"}`;');
+  });
+
+  it("should handle import.meta.url in URL constructor", () => {
+    const code = `const url = new URL("./data.json", import.meta.url);`;
+    const result = replaceImportMeta(code, "file:///test.ts");
+    expect(result).toBe(
+      `const url = new URL("./data.json", "file:///test.ts");`,
+    );
+  });
+
+  it("should handle complex expressions with import.meta.url", () => {
+    const code = `
+      const isFile = import.meta.url.startsWith("file:");
+      const pathname = new URL(import.meta.url).pathname;
+      const urls = [import.meta.url, import.meta.url];
+    `;
+    const result = replaceImportMeta(code, "file:///test.ts");
+    expect(result).toBe(`
+      const isFile = "file:///test.ts".startsWith("file:");
+      const pathname = new URL("file:///test.ts").pathname;
+      const urls = ["file:///test.ts", "file:///test.ts"];
+    `);
+  });
+
+  it("should handle complex expressions with filename and dirname", () => {
+    const code = `
+      const ext = import.meta.filename.endsWith(".ts");
+      const parent = import.meta.dirname.split("/").pop();
+      const paths = [import.meta.filename, import.meta.dirname];
+      const relative = import.meta.filename.replace(import.meta.dirname, "");
+    `;
+    const result = replaceImportMeta(code, "file:///test/dir/file.ts");
+    const expectedFilename = Deno.build.os === "windows"
+      ? "\\\\test\\\\dir\\\\file.ts"
+      : "/test/dir/file.ts";
+    const expectedDirname = Deno.build.os === "windows"
+      ? "\\\\test\\\\dir"
+      : "/test/dir";
+    expect(result).toBe(`
+      const ext = "${expectedFilename}".endsWith(".ts");
+      const parent = "${expectedDirname}".split("/").pop();
+      const paths = ["${expectedFilename}", "${expectedDirname}"];
+      const relative = "${expectedFilename}".replace("${expectedDirname}", "");
+    `);
+  });
+
+  it("should escape special characters in URLs", () => {
+    const code = `const url = import.meta.url;`;
+    const result = replaceImportMeta(code, 'file:///path/with"quotes".ts');
+    expect(result).toBe(`const url = "file:///path/with\\"quotes\\".ts";`);
+  });
+
+  it("should handle Windows file URLs for filename and dirname", () => {
+    const code = `
+      const url = import.meta.url;
+      const filename = import.meta.filename;
+      const dirname = import.meta.dirname;
+    `;
+
+    // Test Windows file URL
+    const windowsUrl = "file:///C:/Users/test/project/module.ts";
+    const result = replaceImportMeta(code, windowsUrl);
+
+    // On Windows, fromFileUrl returns proper Windows paths
+    const expectedFilename = Deno.build.os === "windows"
+      ? "C:\\\\Users\\\\test\\\\project\\\\module.ts"
+      : "/C:/Users/test/project/module.ts";
+    const expectedDirname = Deno.build.os === "windows"
+      ? "C:\\\\Users\\\\test\\\\project"
+      : "/C:/Users/test/project";
+
+    expect(result).toBe(`
+      const url = "file:///C:/Users/test/project/module.ts";
+      const filename = "${expectedFilename}";
+      const dirname = "${expectedDirname}";
+    `);
+  });
+
+  it("should handle Windows paths with proper escaping", () => {
+    const code = `const filename = import.meta.filename;`;
+
+    // Test with a Windows-style file URL
+    const windowsUrl = "file:///C:/Windows/System32/module.ts";
+    const result = replaceImportMeta(code, windowsUrl);
+
+    // On Windows, the path should contain escaped backslashes
+    if (Deno.build.os === "windows") {
+      expect(result).toBe(
+        `const filename = "C:\\\\Windows\\\\System32\\\\module.ts";`,
+      );
+    } else {
+      // On Unix-like systems, the path remains with forward slashes
+      expect(result).toBe(`const filename = "/C:/Windows/System32/module.ts";`);
+    }
+  });
+
+  it("should replace import.meta.resolve() with new URL().href", () => {
+    const code = `const resolved = import.meta.resolve("./module.ts");`;
+    const result = replaceImportMeta(code, "file:///original/path/main.ts");
+    expect(result).toBe(
+      `const resolved = new URL("./module.ts", "file:///original/path/main.ts").href;`,
+    );
+  });
+
+  it("should handle import.meta.resolve() with various arguments", () => {
+    const testCases = [
+      {
+        code: `import.meta.resolve("../lib/utils.ts")`,
+        expected: `new URL("../lib/utils.ts", "file:///test/main.ts").href`,
+      },
+      {
+        code: `import.meta.resolve("@std/path")`,
+        expected: `new URL("@std/path", "file:///test/main.ts").href`,
+      },
+      {
+        code: `import.meta.resolve(moduleName)`,
+        expected: `new URL(moduleName, "file:///test/main.ts").href`,
+      },
+      {
+        code: `import.meta.resolve(\`./\${name}.ts\`)`,
+        expected: `new URL(\`./\${name}.ts\`, "file:///test/main.ts").href`,
+      },
+    ];
+
+    for (const { code, expected } of testCases) {
+      const result = replaceImportMeta(code, "file:///test/main.ts");
+      expect(result).toBe(expected);
+    }
+  });
+
+  it("should handle import.meta.resolve() with whitespace variations", () => {
+    const testCases = [
+      {
+        code: `import.meta.resolve("./file.ts")`,
+        expected: `new URL("./file.ts", "file:///test.ts").href`,
+      },
+      {
+        code: `import . meta . resolve("./file.ts")`,
+        expected: `new URL("./file.ts", "file:///test.ts").href`,
+      },
+      {
+        code: `import\n.meta.resolve("./file.ts")`,
+        expected: `new URL("./file.ts", "file:///test.ts").href`,
+      },
+      {
+        code: `import.meta.resolve( "./file.ts" )`,
+        expected: `new URL("./file.ts", "file:///test.ts").href`,
+      },
+      {
+        code: `import.meta.resolve(\n  "./file.ts"\n)`,
+        expected: `new URL("./file.ts", "file:///test.ts").href`,
+      },
+    ];
+
+    for (const { code, expected } of testCases) {
+      const result = replaceImportMeta(code, "file:///test.ts");
+      expect(result).toBe(expected);
+    }
+  });
+
+  it("should handle multiple import.meta.resolve() calls", () => {
+    const code = `
+      const a = import.meta.resolve("./a.ts");
+      const b = import.meta.resolve("./b.ts");
+      const urls = [import.meta.resolve("./c.ts"), import.meta.resolve("./d.ts")];
+    `;
+    const result = replaceImportMeta(code, "file:///test/main.ts");
+    expect(result).toBe(`
+      const a = new URL("./a.ts", "file:///test/main.ts").href;
+      const b = new URL("./b.ts", "file:///test/main.ts").href;
+      const urls = [new URL("./c.ts", "file:///test/main.ts").href, new URL("./d.ts", "file:///test/main.ts").href];
+    `);
+  });
+
+  it("should handle import.meta.resolve() in complex expressions", () => {
+    const code = `
+      const url = new URL(import.meta.resolve("./data.json"));
+      const isLocal = import.meta.resolve("./file.ts").startsWith("file:");
+      await import(import.meta.resolve("./module.ts"));
+    `;
+    const result = replaceImportMeta(code, "file:///app/main.ts");
+    expect(result).toBe(`
+      const url = new URL(new URL("./data.json", "file:///app/main.ts").href);
+      const isLocal = new URL("./file.ts", "file:///app/main.ts").href.startsWith("file:");
+      await import(new URL("./module.ts", "file:///app/main.ts").href);
+    `);
+  });
+
+  it("should handle all import.meta properties and methods together", () => {
+    const code = `
+      const url = import.meta.url;
+      const filename = import.meta.filename;
+      const dirname = import.meta.dirname;
+      const resolved = import.meta.resolve("./lib.ts");
+    `;
+    const result = replaceImportMeta(code, "file:///project/src/main.ts");
+    const expectedFilename = Deno.build.os === "windows"
+      ? "\\\\project\\\\src\\\\main.ts"
+      : "/project/src/main.ts";
+    const expectedDirname = Deno.build.os === "windows"
+      ? "\\\\project\\\\src"
+      : "/project/src";
+
+    expect(result).toContain(`const url = "file:///project/src/main.ts";`);
+    expect(result).toContain(`const filename = "${expectedFilename}";`);
+    expect(result).toContain(`const dirname = "${expectedDirname}";`);
+    expect(result).toContain(
+      `const resolved = new URL("./lib.ts", "file:///project/src/main.ts").href;`,
+    );
+  });
+});
+
+describe("createOriginalUrlComment", () => {
+  it("should create a proper comment banner", () => {
+    const comment = createOriginalUrlComment("file:///original/module.ts");
+    expect(comment).toContain("// Original source: file:///original/module.ts");
+    expect(comment).toContain(
+      "// This file has been transformed by ImportMapImporter",
+    );
+    expect(comment).toContain(
+      "// import.meta.url, import.meta.filename, import.meta.dirname, and import.meta.resolve() have been replaced",
+    );
+  });
+});

--- a/testdata/import_meta_all.ts
+++ b/testdata/import_meta_all.ts
@@ -1,0 +1,21 @@
+// Test file that uses all import.meta properties
+export const metaUrl = import.meta.url;
+export const metaFilename = import.meta.filename;
+export const metaDirname = import.meta.dirname;
+
+export function getFileInfo() {
+  return {
+    url: import.meta.url,
+    filename: import.meta.filename,
+    dirname: import.meta.dirname,
+    basename: import.meta.filename.split(/[/\\]/).pop(),
+  };
+}
+
+// Use in expressions
+export const isTypeScript = import.meta.filename.endsWith(".ts");
+export const parentDir = import.meta.dirname.split(/[/\\]/).pop();
+
+// Use in path construction
+export const dataPath = import.meta.dirname + "/data";
+export const configPath = `${import.meta.dirname}/config.json`;

--- a/testdata/import_meta_resolve.ts
+++ b/testdata/import_meta_resolve.ts
@@ -1,0 +1,21 @@
+// Test file to understand import.meta.resolve() behavior
+export const resolvedUrl = import.meta.resolve("./dep1.ts");
+export const resolvedRelative = import.meta.resolve("../testdata/dep2.ts");
+export const resolvedBare = import.meta.resolve("@std/path");
+
+export function resolveCustom(path: string) {
+  return import.meta.resolve(path);
+}
+
+// Use in various contexts
+export const resolvedInExpression = new URL(import.meta.resolve("./data.json"));
+export const resolvedArray = [
+  import.meta.resolve("./file1.ts"),
+  import.meta.resolve("./file2.ts"),
+];
+
+// Dynamic resolution
+export async function resolveDynamic(moduleName: string) {
+  const url = import.meta.resolve(moduleName);
+  return url;
+}

--- a/testdata/import_meta_url.ts
+++ b/testdata/import_meta_url.ts
@@ -1,0 +1,13 @@
+// Test file to verify import.meta.url handling
+export const currentUrl = import.meta.url;
+export const dirname = new URL(".", import.meta.url).pathname;
+
+export function getRelativePath(path: string): string {
+  return new URL(path, import.meta.url).href;
+}
+
+export const metadata = {
+  url: import.meta.url,
+  protocol: new URL(import.meta.url).protocol,
+  pathname: new URL(import.meta.url).pathname,
+};


### PR DESCRIPTION
## Summary
- Added functionality to replace `import.meta.url`, `import.meta.filename`, `import.meta.dirname`, and `import.meta.resolve()` with their original values when modules are transformed
- This ensures that transformed modules maintain correct references to their original locations
- Added comprehensive tests for all import.meta property replacements

## Changes
1. **Created `replace_import_meta_url.ts`**: New module that handles replacement of all import.meta properties
2. **Updated `import_map_importer.ts`**: Integrated import.meta replacement into the module transformation process
3. **Added test files**: Created comprehensive test suite to verify import.meta replacements work correctly
4. **Updated `deno.jsonc`**: Excluded testdata directory from the Deno project

## Test plan
- [x] Run `deno test` to verify all tests pass
- [x] Test import.meta.url replacement in transformed modules
- [x] Test import.meta.filename and import.meta.dirname replacements
- [x] Test import.meta.resolve() replacement
- [x] Test with nested dependencies and import mappings
- [x] Test various usage patterns and edge cases

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced support for `import.meta` properties and methods (`url`, `filename`, `dirname`, `resolve()`) in module imports, ensuring accurate metadata and path resolution across modules.
  * All transformed and cached modules now include a comment banner with the original module URL for improved traceability.

* **Bug Fixes**
  * Ensured modules referencing `import.meta` properties are properly transformed and cached, even if they do not contain import statements.

* **Tests**
  * Added comprehensive test suites verifying correct handling and transformation of `import.meta` properties and methods in various scenarios.

* **Chores**
  * Excluded all files and directories under "testdata" from global operations respecting the exclude setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->