### PR TITLE
feat: Add resolveImportMap utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,47 @@ URL:
 }
 ```
 
+### `resolveImportMap`
+
+A utility function to resolve relative paths in import map objects.
+
+This function takes an `ImportMap` object and resolves all relative paths to
+absolute file URLs based on a specified base path. Unlike `loadImportMap` which
+reads from a JSON file, this function works with import map objects directly,
+making it useful for programmatically generated or modified import maps.
+
+```typescript
+import { assertEquals } from "@std/assert";
+import {
+  type ImportMap,
+  ImportMapImporter,
+  resolveImportMap,
+} from "@lambdalisue/import-map-importer";
+
+const rawImportMap: ImportMap = {
+  imports: {
+    "@utils/": "./src/utils/",
+    "lodash": "https://cdn.skypack.dev/lodash",
+  },
+};
+
+// Resolve relative paths in the import map object using a base path
+const importMap = resolveImportMap(rawImportMap, {
+  path: "/project/config/import_map.json",
+});
+
+// The resolved import map will have absolute URLs for relative paths
+assertEquals(importMap, {
+  imports: {
+    "@utils/": "file:///project/config/src/utils/",
+    "lodash": "https://cdn.skypack.dev/lodash",
+  },
+});
+
+// Use with ImportMapImporter
+const importer = new ImportMapImporter(importMap);
+```
+
 ## Performance Tips
 
 1. **Reuse Importer Instances** - Create one importer and reuse it for multiple

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,7 +4,8 @@
     ".": "./mod.ts",
     "./import-map": "./import_map.ts",
     "./import-map-importer": "./import_map_importer.ts",
-    "./load-import-map": "./load_import_map.ts"
+    "./load-import-map": "./load_import_map.ts",
+    "./resolve-import-map": "./resolve_import_map.ts"
   },
   "publish": {
     "include": [

--- a/load_import_map.ts
+++ b/load_import_map.ts
@@ -1,7 +1,7 @@
-import { dirname, isAbsolute, join, toFileUrl } from "@std/path";
 import { ensure } from "@core/unknownutil";
 import type { ImportMap } from "./import_map.ts";
 import { isImportMap } from "./import_map.ts";
+import { resolveImportMap } from "./resolve_import_map.ts";
 
 /**
  * Loads an import map from a JSON file and resolves relative paths.
@@ -45,88 +45,12 @@ import { isImportMap } from "./import_map.ts";
  * ```
  */
 export async function loadImportMap(path: string): Promise<ImportMap> {
-  // Resolve the path to absolute if it's relative
-  const absolutePath = isAbsolute(path) ? path : join(Deno.cwd(), path);
-
   // Read and parse the import map file
-  const content = await Deno.readTextFile(absolutePath);
+  const content = await Deno.readTextFile(path);
   const rawImportMap = JSON.parse(content);
 
   // Validate the import map structure
   const importMap = ensure(rawImportMap, isImportMap);
 
-  // Get the directory of the import map file for resolving relative paths
-  const importMapDir = dirname(absolutePath);
-
-  // Resolve relative paths in imports
-  const resolvedImports: Record<string, string> = {};
-  for (const [key, value] of Object.entries(importMap.imports)) {
-    resolvedImports[key] = resolveImportPath(value, importMapDir);
-  }
-
-  // Resolve relative paths in scopes if they exist
-  let resolvedScopes: Record<string, Record<string, string>> | undefined;
-  if (importMap.scopes) {
-    resolvedScopes = {};
-    for (const [scopeKey, scopeImports] of Object.entries(importMap.scopes)) {
-      // Resolve the scope key itself if it's relative
-      const resolvedScopeKey = resolveImportPath(scopeKey, importMapDir);
-
-      // Resolve the imports within this scope
-      const resolvedScopeImports: Record<string, string> = {};
-      for (const [importKey, importValue] of Object.entries(scopeImports)) {
-        resolvedScopeImports[importKey] = resolveImportPath(
-          importValue,
-          importMapDir,
-        );
-      }
-
-      resolvedScopes[resolvedScopeKey] = resolvedScopeImports;
-    }
-  }
-
-  return {
-    imports: resolvedImports,
-    ...(resolvedScopes && { scopes: resolvedScopes }),
-  };
-}
-
-/**
- * Resolves a path in an import map relative to a base directory.
- *
- * @param path - The path to resolve (can be relative, absolute, or a URL)
- * @param baseDir - The base directory to resolve relative paths against
- * @returns The resolved path as a URL string
- */
-function resolveImportPath(path: string, baseDir: string): string {
-  // If it's already a URL (http://, https://, file://), return as-is
-  if (isUrl(path)) {
-    return path;
-  }
-
-  // If it's a relative path (starts with ./ or ../)
-  if (path.startsWith("./") || path.startsWith("../")) {
-    const resolvedPath = join(baseDir, path);
-    return toFileUrl(resolvedPath).href;
-  }
-
-  // If it's an absolute path
-  if (isAbsolute(path)) {
-    return toFileUrl(path).href;
-  }
-
-  // Otherwise, return as-is (could be a bare specifier or other pattern)
-  return path;
-}
-
-/**
- * Checks if a string is a valid URL.
- */
-function isUrl(str: string): boolean {
-  try {
-    new URL(str);
-    return true;
-  } catch {
-    return false;
-  }
+  return resolveImportMap(importMap, { path });
 }

--- a/mod.ts
+++ b/mod.ts
@@ -11,3 +11,4 @@ export {
   type ImportMapImporterOptions,
 } from "./import_map_importer.ts";
 export { loadImportMap } from "./load_import_map.ts";
+export { resolveImportMap } from "./resolve_import_map.ts";

--- a/resolve_import_map.ts
+++ b/resolve_import_map.ts
@@ -1,0 +1,142 @@
+import { dirname, isAbsolute, join, toFileUrl } from "@std/path";
+import type { ImportMap } from "./import_map.ts";
+
+/**
+ * Options for {@linkcode resolveImportMap}.
+ */
+export interface ResolveImportMapOptions {
+  /**
+   * Path to the import map JSON file.
+   *
+   * This can be a relative or absolute path. If relative, it will be resolved against
+   * the current working directory. If not provided, it will be treated as an unknown
+   * file in the current working directory.
+   *
+   * @default "/path/to/cwd/<unknown>"
+   */
+  path?: string;
+}
+
+/**
+ * Resolves relative paths in the import map JSON object.
+ *
+ * This function resolves all relative paths in the imports and scopes sections
+ * of an import map object relative to a specified base path. This ensures that
+ * relative paths work correctly regardless of where the
+ * import map is loaded from.
+ *
+ * @param importMap - The import map object to resolve
+ * @param options - Options for resolving the import map
+ * @returns A new import map object with all paths resolved
+ *
+ * @example
+ * If the current working directory is `/project` and calling this function with
+ * the following import map object and `path` option:
+ * ```typescript ignore
+ * const rawImportMap: ImportMap = {
+ *   imports: {
+ *     "@utils/": "./src/utils/",
+ *     "lodash": "https://cdn.skypack.dev/lodash",
+ *   },
+ * };
+ *
+ * // Resolve relative paths in the import map object
+ * const importMap = resolveImportMap(rawImportMap, {
+ *   path: "./config/import_map.json",
+ * });
+ * ```
+ *
+ * The resolved result will be:
+ * ```json
+ * {
+ *   "imports": {
+ *     "@utils/": "file:///project/config/src/utils/",
+ *     "lodash": "https://cdn.skypack.dev/lodash"
+ *   }
+ * }
+ * ```
+ */
+export function resolveImportMap(
+  importMap: ImportMap,
+  options: ResolveImportMapOptions = {},
+): ImportMap {
+  const { path = "<unknown>" } = options;
+
+  // Resolve the path to absolute if it's relative
+  const absolutePath = isAbsolute(path) ? path : join(Deno.cwd(), path);
+
+  // Get the directory of the import map file for resolving relative paths
+  const importMapDir = dirname(absolutePath);
+
+  // Resolve relative paths in imports
+  const resolvedImports: Record<string, string> = {};
+  for (const [key, value] of Object.entries(importMap.imports)) {
+    resolvedImports[key] = resolveImportPath(value, importMapDir);
+  }
+
+  // Resolve relative paths in scopes if they exist
+  let resolvedScopes: Record<string, Record<string, string>> | undefined;
+  if (importMap.scopes) {
+    resolvedScopes = {};
+    for (const [scopeKey, scopeImports] of Object.entries(importMap.scopes)) {
+      // Resolve the scope key itself if it's relative
+      const resolvedScopeKey = resolveImportPath(scopeKey, importMapDir);
+
+      // Resolve the imports within this scope
+      const resolvedScopeImports: Record<string, string> = {};
+      for (const [importKey, importValue] of Object.entries(scopeImports)) {
+        resolvedScopeImports[importKey] = resolveImportPath(
+          importValue,
+          importMapDir,
+        );
+      }
+
+      resolvedScopes[resolvedScopeKey] = resolvedScopeImports;
+    }
+  }
+
+  return {
+    imports: resolvedImports,
+    ...(resolvedScopes && { scopes: resolvedScopes }),
+  };
+}
+
+/**
+ * Resolves a path in an import map relative to a base directory.
+ *
+ * @param path - The path to resolve (can be relative, absolute, or a URL)
+ * @param baseDir - The base directory to resolve relative paths against
+ * @returns The resolved path as a URL string
+ */
+function resolveImportPath(path: string, baseDir: string): string {
+  // If it's already a URL (http://, https://, file://), return as-is
+  if (isUrl(path)) {
+    return path;
+  }
+
+  // If it's a relative path (starts with ./ or ../)
+  if (path.startsWith("./") || path.startsWith("../")) {
+    const resolvedPath = join(baseDir, path);
+    return toFileUrl(resolvedPath).href;
+  }
+
+  // If it's an absolute path
+  if (isAbsolute(path)) {
+    return toFileUrl(path).href;
+  }
+
+  // Otherwise, return as-is (could be a bare specifier or other pattern)
+  return path;
+}
+
+/**
+ * Checks if a string is a valid URL.
+ */
+function isUrl(str: string): boolean {
+  try {
+    new URL(str);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/resolve_import_map_test.ts
+++ b/resolve_import_map_test.ts
@@ -1,0 +1,230 @@
+import { assertEquals } from "@std/assert";
+import type { ImportMap } from "./import_map.ts";
+import { resolveImportMap } from "./resolve_import_map.ts";
+
+Deno.test("resolveImportMap - resolves relative paths in imports", () => {
+  const importMap: ImportMap = {
+    imports: {
+      "@utils/": "./src/utils/",
+      "@components/": "../components/",
+      "lodash": "https://cdn.skypack.dev/lodash",
+      "/absolute/": "/usr/local/lib/",
+    },
+  };
+
+  const result = resolveImportMap(importMap, {
+    path: "/project/config/import_map.json",
+  });
+
+  // Check that relative paths are resolved to file URLs
+  assertEquals(
+    result.imports["@utils/"],
+    "file:///project/config/src/utils/",
+  );
+  assertEquals(
+    result.imports["@components/"],
+    "file:///project/components/",
+  );
+
+  // Check that URLs remain unchanged
+  assertEquals(
+    result.imports["lodash"],
+    "https://cdn.skypack.dev/lodash",
+  );
+
+  // Check that absolute paths are converted to file URLs
+  assertEquals(
+    result.imports["/absolute/"],
+    "file:///usr/local/lib/",
+  );
+});
+
+Deno.test("resolveImportMap - resolves relative paths in scopes", () => {
+  const importMap: ImportMap = {
+    imports: {
+      "lodash": "https://cdn.skypack.dev/lodash",
+    },
+    scopes: {
+      "./vendor/": {
+        "lodash": "./vendor/lodash/index.js",
+        "react": "https://esm.sh/react",
+      },
+      "https://example.com/": {
+        "lodash": "https://cdn.jsdelivr.net/npm/lodash",
+      },
+    },
+  };
+
+  const result = resolveImportMap(importMap, {
+    path: "/project/config/import_map.json",
+  });
+
+  // Check that scope keys are resolved
+  assertEquals(result.scopes?.["file:///project/config/vendor/"], {
+    "lodash": "file:///project/config/vendor/lodash/index.js",
+    "react": "https://esm.sh/react",
+  });
+
+  // Check that URL scopes remain unchanged
+  assertEquals(result.scopes?.["https://example.com/"], {
+    "lodash": "https://cdn.jsdelivr.net/npm/lodash",
+  });
+});
+
+Deno.test("resolveImportMap - handles bare specifiers without modification", () => {
+  const importMap: ImportMap = {
+    imports: {
+      "react": "react",
+      "@package": "@package",
+      "some-lib": "some-lib",
+    },
+  };
+
+  const result = resolveImportMap(importMap, {
+    path: "/project/import_map.json",
+  });
+
+  // Bare specifiers should remain unchanged
+  assertEquals(result.imports["react"], "react");
+  assertEquals(result.imports["@package"], "@package");
+  assertEquals(result.imports["some-lib"], "some-lib");
+});
+
+Deno.test("resolveImportMap - works with relative path option", () => {
+  const importMap: ImportMap = {
+    imports: {
+      "@test/": "./test/",
+    },
+  };
+
+  // Test with relative path that will be resolved from cwd
+  const result = resolveImportMap(importMap, {
+    path: "./config/import_map.json",
+  });
+
+  assertEquals(
+    result.imports["@test/"],
+    new URL("./config/test/", `file://${Deno.cwd()}/`).href,
+  );
+});
+
+Deno.test("resolveImportMap - handles empty import map", () => {
+  const importMap: ImportMap = {
+    imports: {},
+  };
+
+  const result = resolveImportMap(importMap, {
+    path: "/project/import_map.json",
+  });
+
+  assertEquals(result.imports, {});
+  assertEquals(result.scopes, undefined);
+});
+
+Deno.test("resolveImportMap - preserves file:// URLs", () => {
+  const importMap: ImportMap = {
+    imports: {
+      "@local/": "file:///absolute/path/to/local/",
+      "@relative/": "file://./relative/path/",
+    },
+  };
+
+  const result = resolveImportMap(importMap, {
+    path: "/project/import_map.json",
+  });
+
+  // file:// URLs should remain unchanged
+  assertEquals(result.imports["@local/"], "file:///absolute/path/to/local/");
+  assertEquals(result.imports["@relative/"], "file://./relative/path/");
+});
+
+Deno.test("resolveImportMap - resolves nested relative paths in scopes", () => {
+  const importMap: ImportMap = {
+    imports: {},
+    scopes: {
+      "../external/": {
+        "@utils/": "./utils/",
+        "@lib/": "../lib/",
+      },
+      "/absolute/scope/": {
+        "@utils/": "./utils/",
+      },
+    },
+  };
+
+  const result = resolveImportMap(importMap, {
+    path: "/project/config/import_map.json",
+  });
+
+  // Check relative scope resolution
+  assertEquals(result.scopes?.["file:///project/external/"], {
+    "@utils/": "file:///project/config/utils/",
+    "@lib/": "file:///project/lib/",
+  });
+
+  // Check absolute scope resolution
+  assertEquals(result.scopes?.["file:///absolute/scope/"], {
+    "@utils/": "file:///project/config/utils/",
+  });
+});
+
+Deno.test("resolveImportMap - uses default path when not provided", () => {
+  const importMap: ImportMap = {
+    imports: {
+      "@local/": "./local/",
+    },
+  };
+
+  // Without path option, it should use cwd/<unknown>
+  const result = resolveImportMap(importMap);
+
+  assertEquals(
+    result.imports["@local/"],
+    new URL("./local/", `file://${Deno.cwd()}/`).href,
+  );
+});
+
+Deno.test("resolveImportMap - handles mixed path types", () => {
+  const importMap: ImportMap = {
+    imports: {
+      // Relative paths
+      "@rel1/": "./relative/path1/",
+      "@rel2/": "../relative/path2/",
+      // Absolute paths
+      "@abs/": "/absolute/path/",
+      // URLs
+      "@http/": "http://example.com/modules/",
+      "@file/": "file:///absolute/file/url/",
+      // Bare specifiers
+      "module": "module-name",
+      // Special cases
+      "@dot/": ".",
+      "@dotdot/": "..",
+    },
+  };
+
+  const result = resolveImportMap(importMap, {
+    path: "/project/src/import_map.json",
+  });
+
+  // Check relative paths
+  assertEquals(
+    result.imports["@rel1/"],
+    "file:///project/src/relative/path1/",
+  );
+  assertEquals(result.imports["@rel2/"], "file:///project/relative/path2/");
+
+  // Check absolute path
+  assertEquals(result.imports["@abs/"], "file:///absolute/path/");
+
+  // Check URLs remain unchanged
+  assertEquals(result.imports["@http/"], "http://example.com/modules/");
+  assertEquals(result.imports["@file/"], "file:///absolute/file/url/");
+
+  // Check bare specifier remains unchanged
+  assertEquals(result.imports["module"], "module-name");
+
+  // Check special cases - these are not relative paths in import map context
+  assertEquals(result.imports["@dot/"], ".");
+  assertEquals(result.imports["@dotdot/"], "..");
+});


### PR DESCRIPTION
This function resolves relative paths in import map objects to absolute file URLs based on a specified base path. Unlike `loadImportMap()` which reads from a JSON file, `resolveImportMap()` accepts an ImportMap object directly and resolves all relative paths in both imports and scopes sections.

- Extract path resolution logic from `loadImportMap()` into `resolveImportMap()`
- Add comprehensive test coverage for various path resolution scenarios
- Export the new function from **mod.ts** and add **deno.jsonc** export mapping
- Update **README.md** with usage documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a utility to resolve relative paths in import maps to absolute file URLs.
  * Added documentation and usage examples for the new import map resolution utility.

* **Bug Fixes**
  * None.

* **Documentation**
  * Updated the README with a new section detailing the import map resolution utility.

* **Tests**
  * Added comprehensive tests to verify correct resolution of import map paths.

* **Chores**
  * Updated configuration to export the new utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->