### PR TITLE
feat!: Change imports property to optional in ImportMap type

### DIFF
--- a/import_map.ts
+++ b/import_map.ts
@@ -42,7 +42,7 @@ export type Scopes = Record<string, Imports>;
  */
 export type ImportMap = {
   /** Global import mappings that apply to all modules */
-  readonly imports: Readonly<Imports>;
+  readonly imports?: Readonly<Imports>;
   /** Scope-specific import mappings that override global mappings within specific URL scopes */
   readonly scopes?: Readonly<Scopes>;
 };
@@ -62,6 +62,6 @@ export const isScopes: Predicate<Scopes> = is.RecordOf(isImports, is.String);
  * Ensures the object has the required structure with proper types.
  */
 export const isImportMap: Predicate<ImportMap> = is.ObjectOf({
-  imports: as.Readonly(isImports),
+  imports: as.Optional(as.Readonly(isImports)),
   scopes: as.Optional(as.Readonly(isScopes)),
 });

--- a/import_map_importer.ts
+++ b/import_map_importer.ts
@@ -114,7 +114,7 @@ export class ImportMapImporter {
     this.#clearDenoCache = options.clearDenoCache ?? false;
 
     // Pre-process import map for faster lookups
-    this.#importEntries = Object.entries(this.importMap.imports);
+    this.#importEntries = Object.entries(this.importMap.imports ?? {});
     this.#scopeEntries = new Map();
 
     if (this.importMap.scopes) {

--- a/import_map_importer_bench.ts
+++ b/import_map_importer_bench.ts
@@ -137,7 +137,7 @@ Deno.bench("ImportMapImporter.import() - large import map", async () => {
   // Create a large import map with many entries
   const largeImportMap: ImportMap = {
     imports: {
-      ...importMap.imports,
+      ...(importMap.imports ?? {}),
       // Add many more entries
       ...Object.fromEntries(
         Array.from({ length: 100 }, (_, i) => [

--- a/load_import_map.ts
+++ b/load_import_map.ts
@@ -106,9 +106,12 @@ export async function loadImportMap(
   const importMapDir = dirname(absolutePath);
 
   // Resolve relative paths in imports
-  const resolvedImports: Record<string, string> = {};
-  for (const [key, value] of Object.entries(importMap.imports)) {
-    resolvedImports[key] = resolveImportPath(value, importMapDir);
+  let resolvedImports: Record<string, string> | undefined;
+  if (importMap.imports) {
+    resolvedImports = {};
+    for (const [key, value] of Object.entries(importMap.imports)) {
+      resolvedImports[key] = resolveImportPath(value, importMapDir);
+    }
   }
 
   // Resolve relative paths in scopes if they exist
@@ -133,7 +136,7 @@ export async function loadImportMap(
   }
 
   return {
-    imports: resolvedImports,
+    ...(resolvedImports && { imports: resolvedImports }),
     ...(resolvedScopes && { scopes: resolvedScopes }),
   };
 }


### PR DESCRIPTION
> [!WARNING]
> BREAKING CHANGE: The imports property in `ImportMap` type is now optional. Import maps without the imports field are now valid.

## Summary

This PR makes the imports property optional in the `ImportMap` type, allowing import maps that only contain scopes to be valid.

## Motivation

The import maps specification allows for import maps without the imports field. This change aligns our implementation with the specification.
Users can now expect that valid import map files according to the specification will not cause errors.

## Breaking Changes

- Changed `ImportMap` type to make imports property optional
- Updated type guards to handle optional imports

This affects:
- Type definitions for `ImportMap`
- Code that assumes imports is always defined will need to handle the optional case

## Migration Guide

If you have code that directly accesses `importMap.imports`, update it to handle the optional case:

```typescript
// Before
const entries = Object.entries(importMap.imports);

// After
const entries = Object.entries(importMap.imports ?? {});
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Import maps without a global imports section are now accepted across the API.
- Bug Fixes
  - Prevented runtime errors when imports is absent by safely handling missing mappings during import processing and loading.
- Tests
  - Expanded coverage for edge cases: import maps without imports, scope-only maps, invalid imports types, and custom loader paths.
  - Strengthened assertions for presence and structure of resolved data.
- Chores
  - Updated benchmarks to handle missing imports gracefully without affecting performance measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->